### PR TITLE
Fix invalid xml.

### DIFF
--- a/inkscape driver/axidraw_hatch.inx
+++ b/inkscape driver/axidraw_hatch.inx
@@ -34,7 +34,7 @@ Hatched figures will be grouped with their fills.
   <param name="tolerance" type="float" min="0.1" max="100" _gui-text="   Tolerance (default: 5.0)">5.0</param>
 
   <param name="footer" type="description" xml:space="preserve">
-            (v2.0.1, December 23, 2016)</_param>
+            (v2.0.1, December 23, 2016)</param>
 
   </page>
   <page name="info" _gui-text="More info...">


### PR DESCRIPTION
For Fedora 25, I was able to get AxiDraw working fairly easily:

1. `dnf install` inkscape and python2-lxml packages. This installed the latest inkscape (0.92)
2. copy the extensions files to `~/.config/inkscape/extensions/`

When I started up inkscape, I got an error on loading the hatch extension.

This PR fixes that trivial error.