### PR TITLE
Add certain manual commands to the AxiDraw submenu in Inkscape

### DIFF
--- a/inkscape driver/axidraw_exec_get_version_fw.inx
+++ b/inkscape driver/axidraw_exec_get_version_fw.inx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Get version (firmware)</_name>
+  <id>command.evilmadscientist.axidraw_get_version_firmware</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="manual" _gui-text="AxiDraw: Get version (firmware)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Get version (firmware)
+      </_param>
+      <param name="manualType" type="optiongroup" gui-hidden="true">
+        <_option value="version-check" >AxiDraw: Get version (firmware)</_option>
+      </param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>

--- a/inkscape driver/axidraw_exec_get_version_sw.inx
+++ b/inkscape driver/axidraw_exec_get_version_sw.inx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Get version (software)</_name>
+  <id>command.evilmadscientist.axidraw_get_version_software</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="version" _gui-text="AxiDraw: Get version (software)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Get version (software)
+      </_param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>

--- a/inkscape driver/axidraw_exec_motors_disable.inx
+++ b/inkscape driver/axidraw_exec_motors_disable.inx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Motors XY (disable)</_name>
+  <id>command.evilmadscientist.axidraw_motors_xy_disable</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="manual" _gui-text="AxiDraw: Motors XY (disable)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Motors XY (disable)
+      </_param>
+      <param name="manualType" type="optiongroup" gui-hidden="true">
+        <_option value="disable-motors" >AxiDraw: Motors XY (disable)</_option>
+      </param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>

--- a/inkscape driver/axidraw_exec_motors_enable.inx
+++ b/inkscape driver/axidraw_exec_motors_enable.inx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Motors XY (enable)</_name>
+  <id>command.evilmadscientist.axidraw_motors_xy_enable</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="manual" _gui-text="AxiDraw: Motors XY (enable)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Motors XY (enable)
+      </_param>
+      <param name="manualType" type="optiongroup" gui-hidden="true">
+        <_option value="enable-motors" >AxiDraw: Motors XY (enable)</_option>
+      </param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>

--- a/inkscape driver/axidraw_exec_pen_lower.inx
+++ b/inkscape driver/axidraw_exec_pen_lower.inx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Pen (lower)</_name>
+  <id>command.evilmadscientist.axidraw_pen_lower</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="manual" _gui-text="AxiDraw: Pen (lower)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Pen (lower)
+      </_param>
+      <param name="manualType" type="optiongroup" gui-hidden="true">
+        <_option value="lower-pen" >AxiDraw: Pen (lower)</_option>
+      </param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>

--- a/inkscape driver/axidraw_exec_pen_raise.inx
+++ b/inkscape driver/axidraw_exec_pen_raise.inx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
+  <_name>AxiDraw: Pen (raise)</_name>
+  <id>command.evilmadscientist.axidraw_pen_raise</id>
+  <dependency type="extension">org.inkscape.output.svg.inkscape</dependency>
+  <dependency type="executable" location="extensions">axidraw.py</dependency>
+  <dependency type="executable" location="extensions">inkex.py</dependency>
+  <param name="mode" type="notebook" gui-hidden="true">
+    <page name="manual" _gui-text="AxiDraw: Pen (raise)">
+      <_param name="splashpage" type="description" appearance="header">
+        AxiDraw v1.6.5 - Pen (raise)
+      </_param>
+      <param name="manualType" type="optiongroup" gui-hidden="true">
+        <_option value="raise-pen" >AxiDraw: Pen (raise)</_option>
+      </param>
+    </page>
+  </param>
+  <effect needs-live-preview="false" needs-document="no">
+    <object-type>all</object-type>
+    <effects-menu>
+      <submenu _name="AxiDraw"/>
+    </effects-menu>
+  </effect>
+  <script>
+    <command reldir="extensions" interpreter="python">axidraw.py</command>
+  </script>
+</inkscape-extension>


### PR DESCRIPTION
For simplicity and ease of use, several commonly used commands are added to the AxiDraw submenu in Inkscape (pen control, motor control, and version info). These commands may also be used while AxiDraw Control is open, increasing flexibility and ease of use even more (e.g., being able to quickly raise the pen and/or disable motors before starting a plot without having to close the plot or layers window).

To aid debugging and error reporting, local logging hooks have also been added.