### PR TITLE
Bugfix: Do not draw elements styled "display:none", nor draw their descendants

### DIFF
--- a/inkscape driver/axidraw.py
+++ b/inkscape driver/axidraw.py
@@ -733,6 +733,11 @@ class AxiDrawClass( inkex.Effect ):
 		for node in aNodeList:
 			if self.bStopped:
 				return
+
+			style = simplestyle.parseStyle(node.get('style'))
+			if 'display' in style.keys() and style['display'] == 'none':
+				continue  # Do not plot this object nor its children
+
 			v = node.get( 'visibility', parent_visibility )			# Ignore invisible nodes
 			if v == 'inherit':
 				v = parent_visibility


### PR DESCRIPTION
Bugfix: Layers / elements hidden via the UI (which styles the element "display:none") should not be printed. 