### PR TITLE
Added tqdm progress bar for visualising plotting process.

### DIFF
--- a/cli/axicli/core.py
+++ b/cli/axicli/core.py
@@ -154,6 +154,10 @@ def axidraw_CLI():
             action="store_const", const='True', \
             help="Report time elapsed")
 
+    parser.add_argument("--progress_bar", \
+            action="store_const", const='True', \
+            help="Show progress bar.")
+
     parser.add_argument("-M","--manual_cmd", \
             metavar='COMMAND', type=str, \
             help="Manual command. One of: [ebb_version, lower_pen, raise_pen, "\
@@ -324,7 +328,7 @@ def axidraw_CLI():
     config_file = common_options.load_config(args.config)
     option_names = ["mode", "speed_pendown", "speed_penup", "accel", "pen_pos_down", "pen_pos_up",
                     "pen_rate_lower", "pen_rate_raise", "pen_delay_down", "pen_delay_up", "reordering",
-                    "no_rotate", "const_speed", "report_time", "manual_cmd", "walk_dist", "layer",
+                    "no_rotate", "const_speed", "report_time", "progress_bar", "manual_cmd", "walk_dist", "layer",
                     "copies", "page_delay", "preview", "rendering", "model", "port", "port_config"]
     common_options.assign_option_values(adc.options, args, [config_file], option_names)
 

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -101,6 +101,7 @@ class AxiDraw(inkex.Effect):
         # which elements have received a warning
         self.warnings = {}
 
+
     def set_defaults(self):
         # Set default values of certain parameters
         # These are set when the class is initialized.
@@ -613,20 +614,17 @@ class AxiDraw(inkex.Effect):
         self.vel_data_chart2.append(" {0:0.3f} {1:0.3f}".format(temp_time, 8.5 - v2 / scale_factor))
         self.vel_data_chart_t.append(" {0:0.3f} {1:0.3f}".format(temp_time, 8.5 - v_total / scale_factor))
 
+
     def update_progress_bar(self):
+
         # Update tqdm progress bar.
         if self.options.progress_bar and not self.options.preview:
-            # The n_steps sets the frequency at which the progress bar
-            # is updated. 
-            n_steps = 1
-            if self.svg_steps_size > 100:
-                n_steps = int(self.svg_steps_size/100)
             self.steps_count += 1
-            if self.steps_count % n_steps == 0:
-                self.tqdm_pbar.update(n_steps)
+            self.tqdm_pbar.update(1)
 
         if self.options.preview:
             self.steps_count += 1
+
 
     def plot_document(self):
         # Plot the actual SVG document, if so selected in the interface
@@ -638,7 +636,12 @@ class AxiDraw(inkex.Effect):
             return
 
         if self.options.progress_bar and not self.options.preview:
-            self.tqdm_pbar = tqdm.tqdm(total=int(self.svg_steps_size), leave=False)
+            self.tqdm_pbar = tqdm.tqdm(
+                                    desc='Printing progress',
+                                    total=int(self.svg_steps_size),
+                                    leave=False, 
+                                    unit='steps'
+                                )
 
         if not self.getDocProps():
             # Error: This document appears to have inappropriate (or missing) dimensions.

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -101,7 +101,6 @@ class AxiDraw(inkex.Effect):
         # which elements have received a warning
         self.warnings = {}
 
-
     def set_defaults(self):
         # Set default values of certain parameters
         # These are set when the class is initialized.

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -3140,7 +3140,7 @@ class AxiDraw(inkex.Effect):
         # For interactive-mode use as an imported python module
         inkex.localize()
         self.getoptions([])
-        self.options.units = 1 # inches, by default
+        self.options.units = 0 # inches, by default
         self.options.preview = False
         self.options.mode = "interactive"
         self.Secondary = False

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -101,7 +101,6 @@ class AxiDraw(inkex.Effect):
         # which elements have received a warning
         self.warnings = {}
 
-
     def set_defaults(self):
         # Set default values of certain parameters
         # These are set when the class is initialized.
@@ -614,7 +613,6 @@ class AxiDraw(inkex.Effect):
         self.vel_data_chart2.append(" {0:0.3f} {1:0.3f}".format(temp_time, 8.5 - v2 / scale_factor))
         self.vel_data_chart_t.append(" {0:0.3f} {1:0.3f}".format(temp_time, 8.5 - v_total / scale_factor))
 
-
     def update_progress_bar(self):
         # Update tqdm progress bar.
         if self.options.progress_bar and not self.options.preview:
@@ -629,7 +627,6 @@ class AxiDraw(inkex.Effect):
 
         if self.options.preview:
             self.steps_count += 1
-
 
     def plot_document(self):
         # Plot the actual SVG document, if so selected in the interface

--- a/cli/pyaxidraw/axidraw_conf.py
+++ b/cli/pyaxidraw/axidraw_conf.py
@@ -47,6 +47,7 @@ pen_delay_down = 0      # Optional delay after pen is lowered (ms)
 
 const_speed = False     # Use constant velocity mode when pen is down.
 report_time = False     # Report time elapsed.
+progress_bar = False    # Show progress bar.
 default_layer = 1       # Layer(s) selected for layers mode (1-1000).
 
 copies = 1              # Copies to plot, or 0 for continuous plotting. Default: 1

--- a/cli/pyaxidraw/axidraw_control.py
+++ b/cli/pyaxidraw/axidraw_control.py
@@ -211,6 +211,7 @@ class AxiDrawWrapperClass( inkex.Effect ):
         ad.options.no_rotate        = self.options.no_rotate
         ad.options.const_speed      = self.options.const_speed
         ad.options.report_time      = self.options.report_time
+        ad.options.progress_bar     = self.options.progress_bar
         ad.options.manual_cmd       = self.options.manual_cmd
         ad.options.walk_dist        = self.options.walk_dist
         ad.options.layer            = self.options.layer

--- a/cli/pyaxidraw/axidraw_options/common_options.py
+++ b/cli/pyaxidraw/axidraw_options/common_options.py
@@ -68,6 +68,11 @@ def core_options(parser, config):
                        default=config["report_time"],\
                        help="Report time elapsed")
 
+    options.add_option("--progress_bar",\
+                       type="inkbool", action="store", dest="progress_bar",\
+                       default=config["progress_bar"],\
+                       help="Show progress bar")
+    
     options.add_option("--page_delay",\
                        type="int", action="store", dest="page_delay",\
                        default=config["page_delay"],\

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,2 +1,3 @@
 lxml==4.2.5
 pyserial==3.0
+tqdm

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,2 @@
 lxml==4.2.5
 pyserial==3.0
-tqdm

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,6 +24,7 @@ setup(
     author_email='contact@evilmadscientist.com',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
+        'tqdm',
         'ink_extensions',
         'lxml',
         'pyserial>=2.7.0' # 3.0 recommended


### PR DESCRIPTION
Example usage:

`axicli /path/to/file.svg --preview -o /path/to/file.svg`
`axicli /path/to/file.svg --progress_bar`

As mentioned in the https://github.com/evil-mad/axidraw/issues/70, the first command should be run at least once before running the actual plot, because it generates the data needed for the progress bar functionality.