### PR TITLE
Add support for unit mm in interactive mode

### DIFF
--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -3145,10 +3145,14 @@ class AxiDraw(inkex.Effect):
         Commands directing movement outside of the bounds are clipped
         with pen up.
         """
-        
-        if self.options.units: # If using centimeter units
+
+        if self.options.units == 1:  # If using centimeter units
             x_value = x_value / 2.54
             y_value = y_value / 2.54
+        elif self.options.units == 2:  # If using millimeter units
+            x_value = x_value / 25.4
+            y_value = y_value / 25.4
+
         if relative:
             x_value = self.turtle_x + x_value
             y_value = self.turtle_y + y_value


### PR DESCRIPTION
I was giving the interactive API a try and noticed that when the units are set to mm the distance moved does not match what is expected.

Looking over the code, it seems like the `mm` unit case was simply omitted and anything other than a value of `0` turns into `cm` for distance. 

I believe this PR resolves the issue, but let me know if I missed anything (or simply misunderstood how to get `mm` units to work in the first place).