### PR TITLE
Speed up plot_optimizations.reorder() with Hilbert Curve

### DIFF
--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -9,3 +9,4 @@ plotink>=1.3.1
 pyserial>=3.5
 requests==2.25.1
 urllib3==1.26.5
+hilbertcurve==2.0.5

--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -9,4 +9,3 @@ plotink>=1.3.1
 pyserial>=3.5
 requests==2.25.1
 urllib3==1.26.5
-hilbertcurve==2.0.5

--- a/inkscape driver/plot_optimizations.py
+++ b/inkscape driver/plot_optimizations.py
@@ -50,7 +50,6 @@ These functions include:
 """
 
 import random
-import math
 import time
 import copy
 

--- a/inkscape driver/plot_optimizations.py
+++ b/inkscape driver/plot_optimizations.py
@@ -50,6 +50,7 @@ These functions include:
 """
 
 import random
+import math
 import time
 import copy
 
@@ -58,6 +59,8 @@ from axidrawinternal.plot_utils_import import from_dependency_import # plotink
 from hilbertcurve import hilbertcurve
 path_objects = from_dependency_import('axidrawinternal.path_objects')
 plot_utils = from_dependency_import('plotink.plot_utils')
+
+CURVE_DISTANCE = 100
 
 def connect_nearby_ends(digest, reverse, min_gap):
     """
@@ -257,8 +260,8 @@ def reorder(digest, reverse):
             if len(spatial_index) == 0:
                 break
             
-            candidate_indexes = spatial_index[current_pos:current_pos+5]
-            candidate_indexes += spatial_index[max(0, current_pos-1):current_pos-5:-1]
+            candidate_indexes = spatial_index[current_pos:current_pos+CURVE_DISTANCE]
+            candidate_indexes += spatial_index[max(0, current_pos-1):current_pos-CURVE_DISTANCE:-1]
             
             #print('--> candidate indexes:', candidate_indexes)
             

--- a/inkscape driver/plot_optimizations.py
+++ b/inkscape driver/plot_optimizations.py
@@ -50,10 +50,12 @@ These functions include:
 """
 
 import random
+import time
 import copy
 
 from . import rtree
 from axidrawinternal.plot_utils_import import from_dependency_import # plotink
+from hilbertcurve import hilbertcurve
 path_objects = from_dependency_import('axidrawinternal.path_objects')
 plot_utils = from_dependency_import('plotink.plot_utils')
 
@@ -218,6 +220,24 @@ def reorder(digest, reverse):
 
         if available_count < 1:
             continue # No paths to sort; move on to next layer
+        
+        start = time.time()
+        curve = hilbertcurve.HilbertCurve(3, 2)
+        distance_points = []
+        for (index, path) in enumerate(available_paths):
+            distance_points.append((
+                curve.distance_from_point(path.first_point()),
+                index,
+            ))
+            if reverse:
+                # We can start at the ends of paths so note those too
+                distance_points.append((
+                    curve.distance_from_point(path.last_point()),
+                    index + available_count,
+                ))
+        spatial_index = [point_index for (_, point_index) in sorted(distance_points)]
+        logging.debug(f'Built spatial index in {time.time() - start:.3f}sec')
+        print('spatial_index:', spatial_index)
 
         rev_path = False    # Flag: Should the current poly be reversed, if it is the best?
         rev_best = False    # Flag for if the "best" poly should be reversed

--- a/inkscape driver/rtree.py
+++ b/inkscape driver/rtree.py
@@ -63,7 +63,7 @@ class Index:
             self.ymax = max(self.ymax, ymax)
 
         # Make four lists of bboxes, one for each quadrant around the center point
-        # An original bbox may be present in more than one list
+        # An original bbox may be present in more than one list, unless zero-area
         sub_bboxes = [
             [
                 (i, (x_1, y_1, x_2, y_2)) for (i, (x_1, y_1, x_2, y_2)) in bboxes
@@ -109,7 +109,9 @@ class Index:
         return ids
     
     def ordered_ids(self):
-        '''
+        ''' Get a list of all IDs in this tree.
+        
+            Repetitions are possible for non-zero-area bounding boxes.
         '''
         ids = list()
         

--- a/inkscape driver/rtree.py
+++ b/inkscape driver/rtree.py
@@ -42,6 +42,8 @@ import enum
 
 
 class D (enum.Enum):
+    ''' Hilbert curve orientations: cardinal direction of the closed "U"
+    '''
     NORTH = 1
     EAST = 2
     SOUTH = 3
@@ -97,18 +99,19 @@ class Index:
             # One of the subtrees is identical to the whole tree so just keep all the bboxes
             self.bboxes = bboxes
         else:
+            # Imitate a Hilbert curve by choosing one of four orders for subtrees
             if direction == D.SOUTH:
-                order = (nw, D.EAST), (sw, D.SOUTH), (se, D.SOUTH), (ne, D.WEST)
+                subtrees = (nw, D.EAST), (sw, D.SOUTH), (se, D.SOUTH), (ne, D.WEST)
             elif direction == D.EAST:
-                order = (nw, D.SOUTH), (ne, D.EAST), (se, D.EAST), (sw, D.NORTH)
+                subtrees = (nw, D.SOUTH), (ne, D.EAST), (se, D.EAST), (sw, D.NORTH)
             elif direction == D.WEST:
-                order = (se, D.NORTH), (sw, D.WEST), (nw, D.WEST), (ne, D.SOUTH)
+                subtrees = (se, D.NORTH), (sw, D.WEST), (nw, D.WEST), (ne, D.SOUTH)
             elif direction == D.NORTH:
-                order = (se, D.NORTH), (ne, D.NORTH), (nw, D.NORTH), (sw, D.EAST)
+                subtrees = (se, D.NORTH), (ne, D.NORTH), (nw, D.NORTH), (sw, D.EAST)
             else:
                 raise ValueError(direction)
             # Make four subtrees, one for each quadrant
-            self.subtrees = [Index(sub, d) for (sub, d) in order]
+            self.subtrees = [Index(sub, d) for (sub, d) in subtrees]
 
     def intersection(self, bbox):
         ''' Get a set of IDs for a given bounding box

--- a/inkscape driver/rtree.py
+++ b/inkscape driver/rtree.py
@@ -71,15 +71,15 @@ class Index:
             ],
             [
                 (i, (x_1, y_1, x_2, y_2)) for (i, (x_1, y_1, x_2, y_2)) in bboxes
-                if x_2 > center_x and y_1 < center_y
+                if x_2 >= center_x and y_1 < center_y
             ],
             [
                 (i, (x_1, y_1, x_2, y_2)) for (i, (x_1, y_1, x_2, y_2)) in bboxes
-                if x_1 < center_x and y_2 > center_y
+                if x_1 < center_x and y_2 >= center_y
             ],
             [
                 (i, (x_1, y_1, x_2, y_2)) for (i, (x_1, y_1, x_2, y_2)) in bboxes
-                if x_2 > center_x and y_2 > center_y
+                if x_2 >= center_x and y_2 >= center_y
             ],
         ]
 
@@ -106,4 +106,17 @@ class Index:
             if not is_disjoint:
                 ids |= subt.intersection(bbox)
 
+        return ids
+    
+    def ordered_ids(self):
+        '''
+        '''
+        ids = list()
+        
+        for (i, _) in self.bboxes:
+            ids.append(i)
+        
+        for subt in self.subtrees:
+            ids.extend(subt.ordered_ids())
+        
         return ids

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -140,10 +140,10 @@ start, raw_distance7 = time.time(), layer7.penup_distance()
 plot_optimizations.reorder(Digest(layer7), False)
 print(f'7a. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
 assert layer7.penup_distance() <= raw_distance7
-assert 28586 < layer7.penup_distance() < 28587
+assert 28586 < layer7.penup_distance() < 28614
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer7), True)
 print(f'7b. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
 assert layer7.penup_distance() <= raw_distance7
-assert 12602 < layer7.penup_distance() < 12603
+assert 12436 < layer7.penup_distance() < 12603

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -126,13 +126,13 @@ start, raw_distance6 = time.time(), layer6.penup_distance()
 plot_optimizations.reorder(Digest(layer6), False)
 print(f'6a. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
 assert layer6.penup_distance() <= raw_distance6
-assert 1062 < layer6.penup_distance() < 1397
+assert 1008 < layer6.penup_distance() < 1397
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer6), True)
 print(f'6b. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
 assert layer6.penup_distance() <= raw_distance6
-assert 1037 < layer6.penup_distance() < 1280
+assert 1017 < layer6.penup_distance() < 1280
 
 layer7 = get_svg_layer('stroke-8-mediumblue.svg')
 

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -39,21 +39,23 @@ class Digest:
         self.layers = [layer]
     
 layer1 = Layer([
-    Path((0, 2), (0, 3)),
     Path((0, 0), (0, 1)),
+    Path((0, 2), (0, 3)),
 ])
-start = time.time()
+start, raw_distance1 = time.time(), layer1.penup_distance()
 plot_optimizations.reorder(Digest(layer1), False)
 print(f'1. Done in {time.time() - start:.3f}sec')
+assert layer1.penup_distance() <= raw_distance1
 assert layer1.penup_distance() == 1.0
     
 layer2 = Layer([
-    Path((0, 0), (0, 1)),
     Path((0, 2), (0, 3)),
+    Path((0, 0), (0, 1)),
 ])
-start = time.time()
+start, raw_distance2 = time.time(), layer2.penup_distance()
 plot_optimizations.reorder(Digest(layer2), False)
 print(f'2. Done in {time.time() - start:.3f}sec')
+assert layer2.penup_distance() <= raw_distance2
 assert layer2.penup_distance() == 1.0
     
 layer3 = Layer([
@@ -61,12 +63,14 @@ layer3 = Layer([
     Path((0, 3), (0, 2)),
 ])
 
-start = time.time()
+start, raw_distance3 = time.time(), layer3.penup_distance()
 plot_optimizations.reorder(Digest(layer3), False)
 print(f'3a. Done in {time.time() - start:.3f}sec')
+assert layer3.penup_distance() <= raw_distance3
 assert layer3.penup_distance() == 2.0
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer3), True)
 print(f'3b. Done in {time.time() - start:.3f}sec')
+assert layer3.penup_distance() <= raw_distance3
 assert layer3.penup_distance() == 1.0

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -126,13 +126,13 @@ start, raw_distance6 = time.time(), layer6.penup_distance()
 plot_optimizations.reorder(Digest(layer6), False)
 print(f'6a. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
 assert layer6.penup_distance() <= raw_distance6
-assert 1062 < layer6.penup_distance() < 1063
+assert 1062 < layer6.penup_distance() < 1397
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer6), True)
 print(f'6b. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
 assert layer6.penup_distance() <= raw_distance6
-assert 1037 < layer6.penup_distance() < 1038
+assert 1037 < layer6.penup_distance() < 1280
 
 layer7 = get_svg_layer('stroke-8-mediumblue.svg')
 
@@ -140,10 +140,10 @@ start, raw_distance7 = time.time(), layer7.penup_distance()
 plot_optimizations.reorder(Digest(layer7), False)
 print(f'7a. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
 assert layer7.penup_distance() <= raw_distance7
-assert 28586 < layer7.penup_distance() < 28614
+assert 28586 < layer7.penup_distance() < 163402
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer7), True)
 print(f'7b. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
 assert layer7.penup_distance() <= raw_distance7
-assert 12436 < layer7.penup_distance() < 12603
+assert 12436 < layer7.penup_distance() < 166320

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -1,9 +1,13 @@
 import sys
 import time
 import math
+import re
+import xml.etree.ElementTree
 
 sys.path.append('inkscape driver')
 import plot_optimizations
+
+xml.etree.ElementTree.register_namespace('', "http://www.w3.org/2000/svg")
 
 class Path:
     start: tuple[float]
@@ -44,7 +48,7 @@ layer1 = Layer([
 ])
 start, raw_distance1 = time.time(), layer1.penup_distance()
 plot_optimizations.reorder(Digest(layer1), False)
-print(f'1. Done in {time.time() - start:.3f}sec')
+print(f'1. Done in {time.time() - start:.3f}sec, from {raw_distance1:.1f} to {layer1.penup_distance():.1f}')
 assert layer1.penup_distance() <= raw_distance1
 assert layer1.penup_distance() == 1.0
     
@@ -54,7 +58,7 @@ layer2 = Layer([
 ])
 start, raw_distance2 = time.time(), layer2.penup_distance()
 plot_optimizations.reorder(Digest(layer2), False)
-print(f'2. Done in {time.time() - start:.3f}sec')
+print(f'2. Done in {time.time() - start:.3f}sec, from {raw_distance2:.1f} to {layer2.penup_distance():.1f}')
 assert layer2.penup_distance() <= raw_distance2
 assert layer2.penup_distance() == 1.0
     
@@ -65,12 +69,81 @@ layer3 = Layer([
 
 start, raw_distance3 = time.time(), layer3.penup_distance()
 plot_optimizations.reorder(Digest(layer3), False)
-print(f'3a. Done in {time.time() - start:.3f}sec')
+print(f'3a. Done in {time.time() - start:.3f}sec, from {raw_distance3:.1f} to {layer3.penup_distance():.1f}')
 assert layer3.penup_distance() <= raw_distance3
 assert layer3.penup_distance() == 2.0
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer3), True)
-print(f'3b. Done in {time.time() - start:.3f}sec')
+print(f'3b. Done in {time.time() - start:.3f}sec, from {raw_distance3:.1f} to {layer3.penup_distance():.1f}')
 assert layer3.penup_distance() <= raw_distance3
 assert layer3.penup_distance() == 1.0
+    
+layer4 = Layer([
+    Path((0, 3), (0, 2)),
+    Path((0, 0), (0, 1)),
+])
+
+start, raw_distance4 = time.time(), layer4.penup_distance()
+plot_optimizations.reorder(Digest(layer4), True)
+print(f'4. Done in {time.time() - start:.3f}sec, from {raw_distance4:.1f} to {layer4.penup_distance():.1f}')
+assert layer4.penup_distance() <= raw_distance4
+assert layer4.penup_distance() == 1.0
+
+def get_svg_layer(path):
+    '''
+    '''
+    path_pattern = re.compile(r'''
+        ^M\ (?P<x1>-?\d+(\.\d+)?)\ (?P<y1>-?\d+(\.\d+)?)
+        \ .+\ 
+        L\ (?P<x2>-?\d+(\.\d+)?)\ (?P<y2>-?\d+(\.\d+)?)
+        \ *$
+    ''', re.VERBOSE)
+    tree = xml.etree.ElementTree.parse(path)
+    return Layer([
+        Path(
+            (float(match.group('x1')), float(match.group('y1'))),
+            (float(match.group('x2')), float(match.group('y2'))),
+        )
+        for match in [
+            path_pattern.match(el.attrib['d'])
+            for el in tree.iter()
+            if el.tag.endswith('}path')
+        ]
+        if match
+    ])
+
+layer5 = get_svg_layer('stroke-10-slateblue.svg')
+start, raw_distance5 = time.time(), layer5.penup_distance()
+plot_optimizations.reorder(Digest(layer5), False)
+print(f'5. Done in {time.time() - start:.3f}sec, from {raw_distance5:.1f} to {layer5.penup_distance():.1f}')
+assert layer5.penup_distance() <= raw_distance5
+assert layer5.penup_distance() == 0., 'Should see zero distance for single path'
+
+layer6 = get_svg_layer('stroke-11-navy.svg')
+
+start, raw_distance6 = time.time(), layer6.penup_distance()
+plot_optimizations.reorder(Digest(layer6), False)
+print(f'6a. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
+assert layer6.penup_distance() <= raw_distance6
+assert 1062 < layer6.penup_distance() < 1063
+
+start = time.time()
+plot_optimizations.reorder(Digest(layer6), True)
+print(f'6b. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
+assert layer6.penup_distance() <= raw_distance6
+assert 1037 < layer6.penup_distance() < 1038
+
+layer7 = get_svg_layer('stroke-8-mediumblue.svg')
+
+start, raw_distance7 = time.time(), layer7.penup_distance()
+plot_optimizations.reorder(Digest(layer7), False)
+print(f'7a. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
+assert layer7.penup_distance() <= raw_distance7
+assert 28586 < layer7.penup_distance() < 28587
+
+start = time.time()
+plot_optimizations.reorder(Digest(layer7), True)
+print(f'7b. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
+assert layer7.penup_distance() <= raw_distance7
+assert 12602 < layer7.penup_distance() < 12603

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -1,0 +1,72 @@
+import sys
+import time
+import math
+
+sys.path.append('inkscape driver')
+import plot_optimizations
+
+class Path:
+    start: tuple[float]
+    end: tuple[float]
+    
+    def __init__(self, start, end):
+        self.start, self.end = start, end
+    
+    def first_point(self):
+        return self.start
+    
+    def last_point(self):
+        return self.end
+    
+    def reverse(self):
+        self.start, self.end = self.end, self.start
+
+class Layer:
+    paths: list[Path]
+
+    def __init__(self, paths):
+        self.paths = paths
+    
+    def penup_distance(self):
+        return sum([
+            math.hypot(p2.start[0] - p1.end[0], p2.start[1] - p1.end[1])
+            for (p1, p2) in zip(self.paths, self.paths[1:])
+        ])
+
+class Digest:
+    layers: list[Layer]
+    def __init__(self, layer):
+        self.layers = [layer]
+    
+layer1 = Layer([
+    Path((0, 2), (0, 3)),
+    Path((0, 0), (0, 1)),
+])
+start = time.time()
+plot_optimizations.reorder(Digest(layer1), False)
+print(f'1. Done in {time.time() - start:.3f}sec')
+assert layer1.penup_distance() == 1.0
+    
+layer2 = Layer([
+    Path((0, 0), (0, 1)),
+    Path((0, 2), (0, 3)),
+])
+start = time.time()
+plot_optimizations.reorder(Digest(layer2), False)
+print(f'2. Done in {time.time() - start:.3f}sec')
+assert layer2.penup_distance() == 1.0
+    
+layer3 = Layer([
+    Path((0, 0), (0, 1)),
+    Path((0, 3), (0, 2)),
+])
+
+start = time.time()
+plot_optimizations.reorder(Digest(layer3), False)
+print(f'3a. Done in {time.time() - start:.3f}sec')
+assert layer3.penup_distance() == 2.0
+
+start = time.time()
+plot_optimizations.reorder(Digest(layer3), True)
+print(f'3b. Done in {time.time() - start:.3f}sec')
+assert layer3.penup_distance() == 1.0

--- a/test_reorder.py
+++ b/test_reorder.py
@@ -95,7 +95,7 @@ def get_svg_layer(path):
     '''
     path_pattern = re.compile(r'''
         ^M\ (?P<x1>-?\d+(\.\d+)?)\ (?P<y1>-?\d+(\.\d+)?)
-        \ .+\ 
+        \ (.+\ )?
         L\ (?P<x2>-?\d+(\.\d+)?)\ (?P<y2>-?\d+(\.\d+)?)
         \ *$
     ''', re.VERBOSE)
@@ -117,33 +117,39 @@ layer5 = get_svg_layer('stroke-10-slateblue.svg')
 start, raw_distance5 = time.time(), layer5.penup_distance()
 plot_optimizations.reorder(Digest(layer5), False)
 print(f'5. Done in {time.time() - start:.3f}sec, from {raw_distance5:.1f} to {layer5.penup_distance():.1f}')
+assert len(layer5.paths) == 1
 assert layer5.penup_distance() <= raw_distance5
 assert layer5.penup_distance() == 0., 'Should see zero distance for single path'
 
 layer6 = get_svg_layer('stroke-11-navy.svg')
+assert len(layer6.paths) == 3424, len(layer6.paths)
 
 start, raw_distance6 = time.time(), layer6.penup_distance()
 plot_optimizations.reorder(Digest(layer6), False)
 print(f'6a. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
+assert len(layer6.paths) == 3424, len(layer6.paths)
 assert layer6.penup_distance() <= raw_distance6
-assert 1008 < layer6.penup_distance() < 1397
+assert 26133 < layer6.penup_distance() < 31146
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer6), True)
 print(f'6b. Done in {time.time() - start:.3f}sec, from {raw_distance6:.1f} to {layer6.penup_distance():.1f}')
+assert len(layer6.paths) == 3424
 assert layer6.penup_distance() <= raw_distance6
-assert 1017 < layer6.penup_distance() < 1280
+assert 10650 < layer6.penup_distance() < 22900
 
 layer7 = get_svg_layer('stroke-8-mediumblue.svg')
 
 start, raw_distance7 = time.time(), layer7.penup_distance()
 plot_optimizations.reorder(Digest(layer7), False)
 print(f'7a. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
+assert len(layer7.paths) == 2118
 assert layer7.penup_distance() <= raw_distance7
 assert 28586 < layer7.penup_distance() < 163402
 
 start = time.time()
 plot_optimizations.reorder(Digest(layer7), True)
 print(f'7b. Done in {time.time() - start:.3f}sec, from {raw_distance7:.1f} to {layer7.penup_distance():.1f}')
+assert len(layer7.paths) == 2118
 assert layer7.penup_distance() <= raw_distance7
 assert 12436 < layer7.penup_distance() < 166320


### PR DESCRIPTION
Follow-up to https://github.com/evil-mad/axidraw/pull/112 speeding up `plot_optimizations.reorder()` for the same reasons.

This pull request introduces a spatial index to reduce needed comparisons with a parameter to trade off time and distance savings. I’ve included some initial results with time improvement over unoptimized and a comparison of pen-up distance reduction after reordering over unoptimized.

The pen-up distance improvements with optimization are generally comparable when `CURVE_DISTANCE = 100` but 80-90% faster to find. These time improvement are a bit less dramatic than the last PR but still meaningful.

The [Hilbert Curve library](https://pypi.org/project/hilbertcurve/) has NumPy as an expensive dependency, so it may be worth trying to port if this approach makes sense.

<table>
<tr>
<th>File</th><th>Paths</th><th><tt>CURVE_DISTANCE</tt></th><th>Time before #113</th><th>Distance savings before #113</th><th>Time after #113</th><th>Distance savings after #113</th><th>Time Improvement</th>
</tr>

<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-10-slateblue.svg">stroke-10-slateblue.svg</a></td><td>1</td><td>5</td><td>0.00 sec</td><td>0%</td><td>0.00 sec</td><td>—</td><td>—</td>
</tr>
<!--
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-11-navy.svg">stroke-11-navy.svg</a></td><td>3,424</td><td>5</td><td>0.00 sec</td><td>36%</td><td>0.00 sec</td><td>30%</td><td>—</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-11-navy.svg">stroke-11-navy.svg</a></td><td>3,424 (reverse)</td><td>5</td><td>0.00 sec</td><td>38%</td><td>0.00 sec</td><td>28%</td><td>—</td>
</tr>
-->
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-8-mediumblue.svg">stroke-8-mediumblue.svg</a></td><td>2,118</td><td>5</td><td>1.72 sec</td><td>88%</td><td>0.12 sec</td><td>64%</td><td>93%</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-8-mediumblue.svg">stroke-8-mediumblue.svg</a></td><td>2,118 (reverse)</td><td>5</td><td>3.24 sec</td><td>95%</td><td>0.13 sec</td><td>63%</td><td>96%</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-10-slateblue.svg">stroke-10-slateblue.svg</a></td><td>1</td><td>100</td><td>0.00 sec</td><td>0%</td><td>0.00 sec</td><td>—</td><td>—</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-11-navy.svg">stroke-11-navy.svg</a></td><td>3,424</td><td>100</td><td>4.63 sec</td><td>90%</td><td>0.52 sec</td><td>88%</td><td>89%</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-11-navy.svg">stroke-11-navy.svg</a></td><td>3,424 (reverse)</td><td>100</td><td>9.07 sec</td><td>96%</td><td>0.68 sec</td><td>91%</td><td>93%</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-8-mediumblue.svg">stroke-8-mediumblue.svg</a></td><td>2,118</td><td>100</td><td>1.72 sec</td><td>88%</td><td>0.32 sec</td><td>85%</td><td>81%</td>
</tr>
<tr>
<td><a href="http://mike.teczno.com/img/axicli-examples-2021-12-19/stroke-8-mediumblue.svg">stroke-8-mediumblue.svg</a></td><td>2,118 (reverse)</td><td>100</td><td>3.24 sec</td><td>95%</td><td>0.39 sec</td><td>88%</td><td>88%</td>
</tr>
</table>


