### PR TITLE
Fix servo timing

### DIFF
--- a/inkscape driver/axidraw.py
+++ b/inkscape driver/axidraw.py
@@ -2334,7 +2334,7 @@ class AxiDraw(inkex.Effect):
             pen_down_pos = self.options.pen_pos_down
 
         v_distance = float(self.options.pen_pos_up - pen_down_pos)
-        v_time = int((1000.0 * v_distance) / (3 * self.options.pen_rate_raise))
+        v_time = int((1000.0 * v_distance) / (4 * self.options.pen_rate_raise))
         if v_time < 0:  # Handle case that pen_pos_down is above pen_pos_up
             v_time = -v_time
         v_time += self.options.pen_delay_up
@@ -2373,7 +2373,7 @@ class AxiDraw(inkex.Effect):
             else:
                 pen_down_pos = self.options.pen_pos_down
             v_distance = float(self.options.pen_pos_up - pen_down_pos)
-            v_time = int((1000.0 * v_distance) / (3 * self.options.pen_rate_lower))
+            v_time = int((1000.0 * v_distance) / (4 * self.options.pen_rate_lower))
             if v_time < 0:  # Handle case that pen_pos_down is above pen_pos_up
                 v_time = -v_time
             v_time += self.options.pen_delay_down
@@ -2481,10 +2481,12 @@ class AxiDraw(inkex.Effect):
             4 * 4.5 = 18 steps/24 ms.
             """
 
-            int_temp = 18 * self.options.pen_rate_raise
+            servo_rate_unit = float(servo_range) / 100.0 / 1000.0 * 24
+            
+            int_temp = int(round(4 * servo_rate_unit * self.options.pen_rate_raise))
             ebb_motion.setPenUpRate(self.serial_port, int_temp)
 
-            int_temp = 18 * self.options.pen_rate_lower
+            int_temp = int(round(4 * servo_rate_unit * self.options.pen_rate_lower))
             ebb_motion.setPenDownRate(self.serial_port, int_temp)
 
             ebb_motion.servo_timeout(self.serial_port, self.params.servo_timeout) # Set timeout


### PR DESCRIPTION
According to the comments in [axidraw/inkscape driver/axidraw.py](https://github.com/evil-mad/axidraw/blob/3fc7991063da068a6880f347bd4a928fb5fbc6e7/inkscape%20driver/axidraw.py#L2474-L2482), 100% of `pen_rate_raise`/`pen_rate_raise` means speeding up to 100% range, defined by `servo_min` and `servo_max`, in 0.25 seconds.
https://github.com/evil-mad/axidraw/blob/3fc7991063da068a6880f347bd4a928fb5fbc6e7/inkscape%20driver/axidraw.py#L2474-L2482 

Previous code use hard-coded SERVO_MAX = 27831 and SERVO_MIN = 9855 for servo rate calculation. This fix takes servo min/max range configurations into account.

This patch also fixes pen up/down time calculation. 100% is 0.25 seconds, hence `4`, not `3`.

I have my custom `servo_min` and `servo_max` configurations. Before the fix, there was a noticeable pause after pen up/down even I set the delays to 0. After the fix, the servo timing is spot on.

