### PR TITLE
Fix moveto() lowering pen

### DIFF
--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -348,6 +348,7 @@ class AxiDraw(axidraw.AxiDraw):
         if not self._verify_interactive(True):
             return
         self.pen.pen_raise(self.options, self.params, self.plot_status)
+        self.turtle_pen_up = True
         self._xy_plot_segment(False,x_target, y_target)
 
     def lineto(self,x_target,y_target):


### PR DESCRIPTION
This might be the quickest way to fix the moveto() bug #137. 

Might be a good idea to have a test suite for the Python API, so bigger changes don't break these basic drawing features.

Aside: I noticed there are some more changes in the `axidraw.py` from https://cdn.evilmadscientist.com/dl/ad/public/AxiDraw_API.zip compared to [the one here on GitHub](https://github.com/evil-mad/axidraw/blob/master/cli/pyaxidraw/axidraw.py), don't know whats going on there...