### PR TITLE
Issue 146

### DIFF
--- a/cli/axicli/axidraw_cli.py
+++ b/cli/axicli/axidraw_cli.py
@@ -70,7 +70,7 @@ from axicli import utils
 from plotink.plot_utils_import import from_dependency_import # plotink
 exit_status = from_dependency_import("ink_extensions_utils.exit_status")
 
-cli_version = "AxiDraw Command Line Interface 3.8.0"
+cli_version = "AxiDraw Command Line Interface 3.8.1"
 
 quick_help = '''
     Basic syntax to plot a file:      axicli svg_in [OPTIONS]

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -24,7 +24,7 @@ https://github.com/evil-mad/AxiDraw
 
 Requires Python 3.7 or newer and Pyserial 3.5 or newer.
 """
-__version__ = '3.8.0'  # Dated 2023-01-01
+__version__ = '3.8.1'  # Dated 2023-02-25
 
 import math
 import gettext

--- a/inkscape driver/axidraw.inx
+++ b/inkscape driver/axidraw.inx
@@ -430,7 +430,7 @@ indent="2" gui-text='Action on "Apply": '>
 
 </param>
 <label indent="5" xml:space="preserve"
->Version 3.8.0      —      Copyright 2023 Evil Mad Science LLC</label>
+>Version 3.8.1      —      Copyright 2023 Evil Mad Science LLC</label>
 
 <effect needs-live-preview="false">
 <object-type>all</object-type>

--- a/inkscape driver/axidraw.py
+++ b/inkscape driver/axidraw.py
@@ -28,7 +28,7 @@ Requires Python 3.7 or newer and Pyserial 3.5 or newer.
 """
 # pylint: disable=pointless-string-statement
 
-__version__ = '3.8.0'  # Dated 2023-01-01
+__version__ = '3.8.1'  # Dated 2023-02-25
 
 import copy
 import gettext

--- a/inkscape driver/digest_svg.py
+++ b/inkscape driver/digest_svg.py
@@ -188,8 +188,10 @@ class DigestSVG:# pylint: disable=pointless-string-statement
 
                     if new_layer.props.skip:
                         continue # Skip Documentation layer and its contents
-                    if self.layer_selection >= 0 and new_layer.props.number is not None:
-                        if self.layer_selection != new_layer.props.number:  # layers mode
+                    if self.layer_selection >= 0: # Plotting in layers mode
+                        if new_layer.props.number is None:
+                            continue
+                        if self.layer_selection != new_layer.props.number:
                             continue # Skip this layer and its contents
 
                     new_layer.item_id = str(self.next_id)
@@ -477,6 +479,11 @@ class DigestSVG:# pylint: disable=pointless-string-statement
 
         # logger.debug('digest_path()\n')
         # logger.debug('path d: ' + path_d)
+
+        if path_d is None:
+            return
+        if path_d == "":
+            return
 
         parsed_path = cubicsuperpath.CubicSuperPath(simplepath.parsePath(path_d))
 


### PR DESCRIPTION
https://github.com/evil-mad/axidraw/issues/146

Also, catch an error that could cause a traceback on an empty path string (already patched in released installers for 3.8.0).