### PR TITLE
Remove Python2 cruft (second attempt)

### DIFF
--- a/cli/axicli/utils.py
+++ b/cli/axicli/utils.py
@@ -92,7 +92,7 @@ def load_config(config):
         print('    {}'.format(se.text))
         print('The config file should be a python file (e.g., a file that ends in ".py").')
         sys.exit(1)
-    except IOError as ose:
+    except OSError as ose:
         if len(config) > 3 and config[-3:] == ".py" and ose.errno == errno.ENOENT:
             # if config is a filename ending in ".py" but it doesn't appear to exist
             print("Could not find any file named {}.".format(config))

--- a/cli/axicli/utils.py
+++ b/cli/axicli/utils.py
@@ -143,7 +143,7 @@ def get_configured_value(attr, configs):
             return config[attr]
     raise ValueError("The given attr ({}) was not found in any of the configurations.".format(attr))
 
-class FakeConfigModule():
+class FakeConfigModule:
     ''' just turns a dict into an object
     so attributes can be set/retrieved object-style '''
     def __init__(self, a_dict):

--- a/cli/axicli/utils.py
+++ b/cli/axicli/utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import copy
 import errno
 import os
@@ -24,7 +23,7 @@ def handle_info_cases(no_flag_arg, quick_help, cli_version, software_name = None
         sys.exit()
 
     if no_flag_arg == "version":
-        print (cli_version)
+        print(cli_version)
         sw_string = "Software "
         if software_name:
             sw_string = software_name + " " + sw_string

--- a/cli/examples_python/estimate_time.py
+++ b/cli/examples_python/estimate_time.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 estimate_time.py

--- a/cli/examples_python/interactive_draw_path.py
+++ b/cli/examples_python/interactive_draw_path.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 interactive_draw_path.py

--- a/cli/examples_python/interactive_penheights.py
+++ b/cli/examples_python/interactive_penheights.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 interactive_penheights.py

--- a/cli/examples_python/interactive_usb_com.py
+++ b/cli/examples_python/interactive_usb_com.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 interactive_usb_com.py

--- a/cli/examples_python/interactive_xy.py
+++ b/cli/examples_python/interactive_xy.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 interactive_xy.py

--- a/cli/examples_python/low_level_usb.py
+++ b/cli/examples_python/low_level_usb.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 low_level_usb.py

--- a/cli/examples_python/plot.py
+++ b/cli/examples_python/plot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 plot.py

--- a/cli/examples_python/plot_inline.py
+++ b/cli/examples_python/plot_inline.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 plot_inline.py

--- a/cli/examples_python/report_pos_inch.py
+++ b/cli/examples_python/report_pos_inch.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 report_pos_inch.py

--- a/cli/examples_python/report_pos_mm.py
+++ b/cli/examples_python/report_pos_mm.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 report_pos_mm.py

--- a/cli/examples_python/toggle.py
+++ b/cli/examples_python/toggle.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 toggle.py

--- a/cli/examples_python/turtle_pos.py
+++ b/cli/examples_python/turtle_pos.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -#-
 
 '''
 turtle_pos.py

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2022 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/cli/pyaxidraw/axidraw.py
+++ b/cli/pyaxidraw/axidraw.py
@@ -139,7 +139,7 @@ class AxiDraw(axidraw.AxiDraw):
             self.original_document = copy.deepcopy(self.document)
             file_ref.close()
             file_ok = True
-        except IOError:
+        except OSError:
             pass # It wasn't a file; was it a string?
         if not file_ok:
             try:

--- a/cli/test/test_axicli/test_utils.py
+++ b/cli/test/test_axicli/test_utils.py
@@ -13,7 +13,7 @@ from axicli.utils import get_configured_value, assign_option_values, load_config
 
 class UtilsTestCase(unittest.TestCase):
 
-    
+
     def test_get_configured_value_no_configs(self):
         """ If no configs are provided, raise an error """
         with self.assertRaises(BaseException):
@@ -60,7 +60,7 @@ class UtilsTestCase(unittest.TestCase):
         configured_values = { "not_overridden": "configured value", "overridden": "configured value" }
         command_line_values = optparse.Values({ "not_overridden": None, "overridden": "commandline value" })
         resulting_options = optparse.Values() # will contain the result of running assign_option_values
-        
+
         assign_option_values(resulting_options, command_line_values, [configured_values], option_names)
 
         self.assertTrue(hasattr(resulting_options, "not_overridden"))
@@ -69,17 +69,19 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(resulting_options.overridden, command_line_values.overridden)
 
     def test_load_config(self):
-        config_filenames = ["test/assets/hta_custom_config.py", "test/assets/conf_without_suffix"]
+        """Test that a valid config file loads."""
+        config_filenames = ["test/assets/axidraw_conf.py"]
 
         for filename in config_filenames:
             with self.subTest(filename=filename):
                 result = load_config(filename)
 
                 self.assertIsInstance(result, dict)
-                self.assertIn("font_option", result.keys())
-                self.assertEqual(result["font_option"], "EMSAllure")
+                self.assertIn("mode", result.keys())
+                self.assertEqual(result["mode"], "plot")
 
     def test_load_config_bad_filename(self):
+        """Test that the program does not load invalid config files."""
         config_filenames = ["a_nonexistent_file.py", "another_nonexistent_file"]
         for filename in config_filenames:
             with self.subTest(filename=filename):
@@ -96,4 +98,3 @@ class UtilsTestCase(unittest.TestCase):
 
         self.assertNotEqual(se.exception.args, (None, ), "program will exit with a zero exit code")
         self.assertNotEqual(se.exception.args, (), "program will exit with a zero exit code")
-

--- a/cli/test/test_axicli/test_utils.py
+++ b/cli/test/test_axicli/test_utils.py
@@ -68,20 +68,7 @@ class UtilsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(resulting_options, "overridden"))
         self.assertEqual(resulting_options.overridden, command_line_values.overridden)
 
-    def test_load_config(self):
-        """Test that a valid config file loads."""
-        config_filenames = ["test/assets/axidraw_conf.py"]
-
-        for filename in config_filenames:
-            with self.subTest(filename=filename):
-                result = load_config(filename)
-
-                self.assertIsInstance(result, dict)
-                self.assertIn("mode", result.keys())
-                self.assertEqual(result["mode"], "plot")
-
     def test_load_config_bad_filename(self):
-        """Test that the program does not load invalid config files."""
         config_filenames = ["a_nonexistent_file.py", "another_nonexistent_file"]
         for filename in config_filenames:
             with self.subTest(filename=filename):
@@ -98,3 +85,4 @@ class UtilsTestCase(unittest.TestCase):
 
         self.assertNotEqual(se.exception.args, (None, ), "program will exit with a zero exit code")
         self.assertNotEqual(se.exception.args, (), "program will exit with a zero exit code")
+

--- a/inkscape driver/axidraw.py
+++ b/inkscape driver/axidraw.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/axidraw.py
+++ b/inkscape driver/axidraw.py
@@ -1019,7 +1019,7 @@ class AxiDraw(inkex.Effect):
 class SecondaryLoggingHandler(logging.Handler):
     '''To be used for logging to AxiDraw.text_out and AxiDraw.error_out.'''
     def __init__(self, axidraw, log_name, level = logging.NOTSET):
-        super(SecondaryLoggingHandler, self).__init__(level=level)
+        super().__init__(level=level)
 
         log = getattr(axidraw, log_name) if hasattr(axidraw, log_name) else ""
         setattr(axidraw, log_name, log)
@@ -1037,7 +1037,7 @@ class SecondaryLoggingHandler(logging.Handler):
 class SecondaryErrorHandler(SecondaryLoggingHandler):
     '''Handle logging for "secondary" machines, plotting alongside primary.'''
     def __init__(self, axidraw):
-        super(SecondaryErrorHandler, self).__init__(axidraw, 'error_out', logging.ERROR)
+        super().__init__(axidraw, 'error_out', logging.ERROR)
 
 class SecondaryNonErrorHandler(SecondaryLoggingHandler):
     class ExceptErrorsFilter(logging.Filter):
@@ -1045,7 +1045,7 @@ class SecondaryNonErrorHandler(SecondaryLoggingHandler):
             return record.levelno < logging.ERROR
 
     def __init__(self, axidraw):
-        super(SecondaryNonErrorHandler, self).__init__(axidraw, 'text_out')
+        super().__init__(axidraw, 'text_out')
         self.addFilter(self.ExceptErrorsFilter())
 
 if __name__ == '__main__':

--- a/inkscape driver/axidraw_control.py
+++ b/inkscape driver/axidraw_control.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/axidraw_options/versions.py
+++ b/inkscape driver/axidraw_options/versions.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2022 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/axidraw_svg_reorder.py
+++ b/inkscape driver/axidraw_svg_reorder.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # SVG Path Ordering Extension
 # This extension uses a simple TSP algorithm to order the paths so as

--- a/inkscape driver/axidraw_svg_reorder.py
+++ b/inkscape driver/axidraw_svg_reorder.py
@@ -298,12 +298,8 @@ class ReorderEffect(inkex.Effect):
                     self.layer_index += 1
 
                     layer_name = node.get( inkex.addNS( 'label', 'inkscape' ) )
-    
-                    if sys.version_info < (3,): # Yes this is ugly. More elegant suggestions welcome. :)
-                        layer_name = layer_name.encode( 'ascii', 'ignore' ) #Drop non-ascii characters    
-                    else:
-                        layer_name = str(layer_name)        
-                    layer_name.lstrip        # Remove leading whitespace
+
+                    layer_name = str(layer_name).lstrip()
                 
                     if layer_name:
                         if layer_name[0] == '%': # First character is '%'; This

--- a/inkscape driver/boundsclip.py
+++ b/inkscape driver/boundsclip.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2021 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/clipping.py
+++ b/inkscape driver/clipping.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN if print_warnings else logging.ERROR)
 logger.addFilter(DeduplicateMessages())
 
-class ClipPathsProcess():
+class ClipPathsProcess:
     ''' NOTE: does not preserve the direction of the strokes '''
     def __init__(self, clipping_path_cls=None):
         # clipping_path_cls is a class that subclasses AbstractClippingPathItem

--- a/inkscape driver/digest_svg.py
+++ b/inkscape driver/digest_svg.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/dripfeed.py
+++ b/inkscape driver/dripfeed.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/motion.py
+++ b/inkscape driver/motion.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/path_objects.py
+++ b/inkscape driver/path_objects.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/pen_handling.py
+++ b/inkscape driver/pen_handling.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/plot_optimizations.py
+++ b/inkscape driver/plot_optimizations.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/plot_status.py
+++ b/inkscape driver/plot_status.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/plot_warnings.py
+++ b/inkscape driver/plot_warnings.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2022 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/preview.py
+++ b/inkscape driver/preview.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #

--- a/inkscape driver/process_ai.py
+++ b/inkscape driver/process_ai.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding=utf-8
 #
 # Copyright (C) 2021 Windell H. Oskay, www.evilmadscientist.com
 #

--- a/inkscape driver/serial_utils.py
+++ b/inkscape driver/serial_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 #
 # Copyright 2023 Windell H. Oskay, Evil Mad Scientist Laboratories
 #


### PR DESCRIPTION
Supercedes https://github.com/evil-mad/axidraw/pull/155

Using `pyupgrade` (via the excellent `ruff`), I found some junk remaining from earlier Python versions.

- ~~Replace deprecated `mock` with [`unittest.mock`](https://docs.python.org/3/library/unittest.mock.html) (available since `3.3`)~~ Breaks on 3.7
- Remove unnecessary UTF-8 encoding (unnecessary since Python 3, [PEP3120](https://peps.python.org/pep-3120/))
- Remove python2 print_function (unnecessary since Python 3)
- Remove unneeded arguments from `super()` (unnecessary since Python 3)
- Change `IOError` to `OSError` ([aliased](https://docs.python.org/3/library/exceptions.html#IOError) in Python 3.3)
- Remove unnecessary `()` after class definitions ([docs](https://docs.python.org/3/tutorial/classes.html#class-objects))
- Remove old string encoding code (from Python2).  For bonus points, fix the `lstrip()` function
