### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: pytest
+
+on:
+  push:
+    branches:
+      - "master"
+      - "renovate/**"
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install https://github.com/evil-mad/axidraw/releases/download/v3.9.0/AxiDraw_API_390.zip
+        cd cli
+        python -m pip install '.[test]'
+#    - name: Lint with ruff
+#      run: |
+#        ruff .
+    - name: Pytest
+      run: |
+        python3 -m unittest discover cli


### PR DESCRIPTION
~~`pytest` was missing as a test dependency, so this adds that.~~ Oops, it's `unittest`

It also sets up a working GitHub Actions CI, which is free for public repos.  I understand that Evil Mad Scientist has an internal CI server somewhere, but this is public and helps other contributors.

Note that `3.9.2` hasn't been [released](https://github.com/evil-mad/axidraw/releases/) 
on GitHub yet so the CI manually downloads `3.9.0`.
