### PR TITLE
version 3.9.3

### DIFF
--- a/cli/axicli/axidraw_cli.py
+++ b/cli/axicli/axidraw_cli.py
@@ -70,7 +70,7 @@ from axicli import utils
 from plotink.plot_utils_import import from_dependency_import # plotink
 exit_status = from_dependency_import("ink_extensions_utils.exit_status")
 
-cli_version = "AxiDraw Command Line Interface 3.9.2"
+cli_version = "AxiDraw Command Line Interface 3.9.3"
 
 quick_help = '''
     Basic syntax to plot a file:      axicli svg_in [OPTIONS]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -2,7 +2,7 @@
 
 name = "axicli"
 
-version = "3.9.2"
+version = "3.9.3"
 
 description = "AxiDraw CLI and Python API"
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -12,7 +12,7 @@ import setuptools
 # specified in pyproject.toml, so it is specified here.
 
 install_requires=[
-        'ink_extensions>=1.2.0',
+        'ink_extensions>=1.3.2',
         'lxml>=4.9.1',
         'plotink>=1.8.0',
         'pyserial>=3.5',

--- a/inkscape driver/axidraw.inx
+++ b/inkscape driver/axidraw.inx
@@ -58,7 +58,7 @@ support, email  contact@evilmadscientist.com  or visit axidraw.com/chat
 <image width="10" height="5">axidraw_deps/axidrawinternal/inx_img/spacer_10px.svg</image>
 
 <label indent="6"
->Version 3.9.2      —      Copyright 2023 Evil Mad Science LLC</label>
+>Version 3.9.3      —      Copyright 2023 Evil Mad Science LLC</label>
 
 
 
@@ -148,7 +148,7 @@ gui-text="Pen-up movement speed (%):   ">75</param>
 
 <param name="pen_rate_raise" type="optiongroup" appearance="combo" gui-text="Pen raising speed :">
 <option value="100">Maximum</option>
-<option value="38">Standard</option>
+<option value="50">Standard</option>
 <option value="25">Slow</option>
 <option value="12">Very slow</option>
 <option value="6">Dead slow</option>

--- a/inkscape driver/axidraw_saveplob.inx
+++ b/inkscape driver/axidraw_saveplob.inx
@@ -43,7 +43,7 @@ gui-text="Specific layer selection:">1</param>
 
 <spacer />
 <spacer />
-<label indent="6">Version 3.9.1. Copyright 2023 Evil Mad Scientist</label>
+<label indent="6">Version 3.9.3. Copyright 2023 Evil Mad Scientist</label>
 
 </page>
 


### PR DESCRIPTION
Add timeout on webhooks
Improved error handling on webhooks
Bug fix for printing a specific layer from a plob that contains multiple layers, which can occur when generating the plob in the API and then using layers mode. Alter value for "standard" pen-lift rate. (Not the default value; a slower value called "standard".)