### PR TITLE
Dependency Version Bumps for Security and Maintenance

### DIFF
--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -7,5 +7,5 @@ lxml==4.9.3
 plotink==1.9.0
 pyserial==3.5
 requests==2.31.0
-tqdm==4.64.0
+tqdm==4.66.3
 urllib3==1.26.18

--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -1,7 +1,7 @@
 axidrawinternal @ git+https://${AXIDRAWINTERNAL_DEPLOY_USER}:${AXIDRAWINTERNAL_DEPLOY_PASS}@gitlab.com/evil-mad/AxiDraw-Internal@master
 certifi==2023.7.22
 charset-normalizer==2.0.7
-idna==3.3
+idna==3.7
 ink-extensions==2.0.0
 lxml==4.9.3
 plotink==1.9.0

--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -8,4 +8,4 @@ plotink==1.9.0
 pyserial==3.5
 requests==2.31.0
 tqdm==4.66.3
-urllib3==1.26.18
+urllib3==2.6.3

--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -1,5 +1,5 @@
 axidrawinternal @ git+https://${AXIDRAWINTERNAL_DEPLOY_USER}:${AXIDRAWINTERNAL_DEPLOY_PASS}@gitlab.com/evil-mad/AxiDraw-Internal@master
-certifi==2023.7.22
+certifi==2024.7.4
 charset-normalizer==2.0.7
 idna==3.3
 ink-extensions==2.0.0

--- a/cli/requirements/requirements.txt
+++ b/cli/requirements/requirements.txt
@@ -6,6 +6,6 @@ ink-extensions==2.0.0
 lxml==4.9.3
 plotink==1.9.0
 pyserial==3.5
-requests==2.31.0
+requests==2.32.4
 tqdm==4.66.3
 urllib3==2.6.3

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -2,7 +2,7 @@ plotink @ git+https://github.com/evil-mad/plotink
 certifi==2023.7.22
 chardet==3.0.4
 charset-normalizer==3.2.0
-idna==2.8
+idna==3.7
 ink-extensions==2.0.0
 lxml==4.9.3
 mpmath==1.3.0

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -12,5 +12,5 @@ pyinstaller==5.13.0
 pyinstaller-hooks-contrib==2023.6
 pyserial==3.5
 requests==2.31.0
-tqdm==4.64.1
+tqdm==4.66.3
 urllib3==1.26.18

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -8,7 +8,7 @@ lxml==4.9.3
 mpmath==1.3.0
 packaging==21.3
 pyclipper==1.3.0.post4
-pyinstaller==5.13.0
+pyinstaller==5.13.1
 pyinstaller-hooks-contrib==2023.6
 pyserial==3.5
 requests==2.31.0

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -1,5 +1,5 @@
 plotink @ git+https://github.com/evil-mad/plotink
-certifi==2023.7.22
+certifi==2024.7.4
 chardet==3.0.4
 charset-normalizer==3.2.0
 idna==3.7

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -11,6 +11,6 @@ pyclipper==1.3.0.post4
 pyinstaller==5.13.1
 pyinstaller-hooks-contrib==2023.6
 pyserial==3.5
-requests==2.31.0
+requests==2.32.4
 tqdm==4.66.3
 urllib3==1.26.18

--- a/inkscape driver/public_build_materials/requirements.txt
+++ b/inkscape driver/public_build_materials/requirements.txt
@@ -8,7 +8,7 @@ lxml==4.9.3
 mpmath==1.3.0
 packaging==21.3
 pyclipper==1.3.0.post4
-pyinstaller==5.13.1
+pyinstaller==6.15.0
 pyinstaller-hooks-contrib==2023.6
 pyserial==3.5
 requests==2.31.0


### PR DESCRIPTION
# Dependency Version Bumps for Security and Maintenance

## Summary

This PR updates several Python package dependencies across two requirements files to their newer versions. The changes primarily address **security vulnerabilities** in outdated packages and bring dependencies closer to current stable releases.

## Files Changed

### 1. `cli/requirements/requirements.txt`
Updates 5 dependencies used by the CLI tool:

| Package | Old Version | New Version |
|---------|------------|-------------|
| `certifi` | 2023.7.22 | **2024.7.4** |
| `idna` | 3.3 | **3.7** |
| `requests` | 2.31.0 | **2.32.4** |
| `tqdm` | 4.64.0 | **4.66.3** |
| `urllib3` | 1.26.18 | **2.6.3** |

### 2. `inkscape driver/public_build_materials/requirements.txt`
Updates 5 dependencies used by the Inkscape driver build:

| Package | Old Version | New Version |
|---------|------------|-------------|
| `certifi` | 2023.7.22 | **2024.7.4** |
| `idna` | 2.8 | **3.7** |
| `pyinstaller` | 5.13.0 | **6.15.0** |
| `requests` | 2.31.0 | **2.32.4** |
| `tqdm` | 4.64.1 | **4.66.3** |

> **Note:** `urllib3` in the Inkscape driver file was intentionally left at `1.26.18` (not bumped to `2.x`), likely due to compatibility constraints with the older `chardet==3.0.4` and `idna` usage in that environment.

## Code Changes

The most significant version jumps are:

```diff
-urllib3==1.26.18
+urllib3==2.6.3
```
`urllib3` 2.x is a **major version upgrade** in the CLI requirements. This version drops support for Python < 3.7, removes deprecated APIs, and changes some default behaviors (e.g., default TLS settings). This is only applied in the CLI requirements, not in the Inkscape driver build.

```diff
-pyinstaller==5.13.0
+pyinstaller==6.15.0
```
`pyinstaller` 6.x is also a **major version upgrade** for the Inkscape driver build tooling. PyInstaller 6 introduced changes to the build process, bootloader behavior, and hook system.

## Reason for Changes

1. **Security patches**: `certifi`, `requests`, `urllib3`, and `idna` all had known CVEs in the previously pinned versions:
   - `certifi` < 2024.7.4 — outdated CA certificate bundle
   - `requests` < 2.32.0 — CVE-2024-35195 (session credential leak on redirects)
   - `idna` < 3.7 — CVE-2024-3651 (DoS via resource consumption)
   - `urllib3` 1.x — multiple advisories around TLS and header injection

2. **Maintenance**: `tqdm` and `pyinstaller` bumps bring bug fixes, performance improvements, and compatibility with newer Python versions.

## Impact of Changes

- **CLI users** will now use `urllib3` 2.x, which has a stricter TLS posture by default. This could surface issues if the AxiDraw communicates with endpoints using outdated TLS configurations or self-signed certificates.
- **Inkscape driver builds** using `pyinstaller` 6.x may produce different build artifacts. The bootloader and hook system changes could affect packaging behavior, binary size, or runtime behavior of the bundled application.
- **No functional code changes** — only dependency versions are modified, so application logic is unaffected.

## Test Plan

1. **CLI**: Install dependencies from `cli/requirements/requirements.txt` into a clean virtual environment and verify:
   - The CLI starts and connects to the AxiDraw hardware successfully.
   - HTTPS requests (if any) complete without TLS errors under `urllib3` 2.x.
   - Run the existing test suite / smoke tests to ensure no regressions.

2. **Inkscape Driver Build**: Install dependencies from `inkscape driver/public_build_materials/requirements.txt` and verify:
   - `pyinstaller` 6.x successfully builds the Inkscape driver bundle.
   - The resulting binary launches and functions correctly within Inkscape.
   - Verify the bundled binary size and startup time are within acceptable range.

3. **Cross-platform verification**: If builds target multiple OS platforms (Windows, macOS, Linux), test on each.

## Additional Notes

- The `urllib3` version was **not** bumped in the Inkscape driver requirements file. This asymmetry should be tracked — it may indicate that the Inkscape driver environment is not yet ready for `urllib3` 2.x, or it may simply have been an oversight. A follow-up to align these would be prudent.
- `pyinstaller-hooks-contrib==2023.6` was **not** updated alongside the `pyinstaller` 6.x bump. It is worth verifying that this older hooks package is compatible with PyInstaller 6.x; newer hooks may be needed for correct bundling behavior.
- Consider adding a `pip-audit` or `safety` check to CI to catch vulnerable dependency versions automatically in the future.
k